### PR TITLE
Move CSS rules into `drawdown.css`

### DIFF
--- a/drawdown.css
+++ b/drawdown.css
@@ -1,0 +1,39 @@
+hr {
+  margin: 1em 0;
+  border: 0;
+  border-bottom: 1px solid #ccc;
+}
+blockquote {
+  margin-left: 0;
+  padding: 0.5em 0 0.5em 2em;
+  border-left: 3px solid rgb(211, 218, 234);
+}
+li, code {
+  margin: 0.4em 0;
+}
+p {
+  margin: 0.9em 0;
+}
+code {
+  background: rgba(211, 218, 234, 0.25);
+}
+pre > code {
+  display: block;
+  padding: 0.5em 4em;
+}
+table {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+td {
+  padding: 4px 8px;
+}
+tr:nth-child(2n) {
+  background: #f3f3f3;
+}
+th {
+  border-bottom: 1px solid #aaa;
+}
+img {
+  max-width: 96px;
+}

--- a/index.html
+++ b/index.html
@@ -16,45 +16,6 @@
       margin: 0;
       overflow: hidden;
     }
-    hr {
-      margin: 1em 0;
-      border: 0;
-      border-bottom: 1px solid #ccc;
-    }
-    blockquote {
-      margin-left: 0;
-      padding: 0.5em 0 0.5em 2em;
-      border-left: 3px solid rgb(211, 218, 234);
-    }
-    li, code {
-      margin: 0.4em 0;
-    }
-    p {
-      margin: 0.9em 0;
-    }
-    code {
-      background: rgba(211, 218, 234, 0.25);
-    }
-    pre > code {
-      display: block;
-      padding: 0.5em 4em;
-    }
-    table {
-      border-spacing: 0;
-      border-collapse: collapse;
-    }
-    td {
-      padding: 4px 8px;
-    }
-    tr:nth-child(2n) {
-      background: #f3f3f3;
-    }
-    th {
-      border-bottom: 1px solid #aaa;
-    }
-    img {
-      max-width: 96px;
-    }
     .plain, .markdown {
       position: absolute;
       width: 50%;
@@ -78,6 +39,7 @@
       line-height: 1.3;
     }
   </style>
+  <link rel="stylesheet" href="drawdown.css">
   <title>drawdown test</title>
 </head>
 <body>


### PR DESCRIPTION
Moves the markdown CSS into an external stylesheet `drawdown.css`, to make it easier to use the styling used in the example, if desired.